### PR TITLE
Use own definition of standard functions instead of relying on string…

### DIFF
--- a/loader/bios.c
+++ b/loader/bios.c
@@ -3,7 +3,7 @@
 #include "io.h"
 #include "util.h"
 #include "debugscreen.h"
-#include <string.h>
+#include "str.h"
 
 // Set to zero unless you are using an emulator or have a physical UART on the PS1, else it'll freeze
 const uint32_t tty_enabled = 0;

--- a/loader/cfgparse.c
+++ b/loader/cfgparse.c
@@ -1,7 +1,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
-#include <string.h>
+#include "str.h"
 #include "str.h"
 #include "bios.h"
 #include "debugscreen.h"

--- a/loader/debugscreen.c
+++ b/loader/debugscreen.c
@@ -1,5 +1,5 @@
 
-#include <string.h>
+#include "str.h"
 #include "debugscreen.h"
 #include "gpu.h"
 #include "bios.h"

--- a/loader/patcher.c
+++ b/loader/patcher.c
@@ -1,7 +1,7 @@
 
 #include "bios.h"
 #include "debugscreen.h"
-#include <string.h>
+#include "str.h"
 #include "patcher.h"
 
 #include "patches.inc"

--- a/loader/secondary.c
+++ b/loader/secondary.c
@@ -2,7 +2,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <string.h>
+#include "str.h"
 #include "audio.h"
 #include "bios.h"
 #include "cdrom.h"

--- a/loader/str.c
+++ b/loader/str.c
@@ -1,6 +1,6 @@
 
 #include "str.h"
-#include <stddef.h>
+#include <stdint.h>
 
 int isspace(int c) {
 	switch (c) {
@@ -110,7 +110,7 @@ int mini_vsprintf(char * str, const char * format, va_list args) {
 
 					case 'x': {
 						char c;
-						uint32_t val = va_arg(args, uint32_t);
+						unsigned int val = va_arg(args, unsigned int);
 						for (int i = 28; i >= 0; i -= 4) {
 							c = (val >> i) & 0xF;
 							if (c < 10) {
@@ -153,7 +153,7 @@ end:
 }
 
 // The BIOS has already this function but for clearing the console's RAM it's unbearably slow.
-void bzero(void * start, uint32_t len) {
+void bzero(void * start, size_t len) {
 	uint8_t * bytes = (uint8_t *) start;
 	while (len) {
 		*bytes = 0;

--- a/loader/str.h
+++ b/loader/str.h
@@ -1,10 +1,24 @@
 
 #pragma once
 #include <stdarg.h>
-#include <stdint.h>
+#include <stddef.h>
+
+void bzero(void * start, size_t len);
+
+void memcpy(void * dest, const void * src, size_t len);
 
 int isspace(int c);
 
 int mini_sprintf(char * str, const char * format, ...);
 
 int mini_vsprintf(char * str, const char * format, va_list args);
+
+int strlen(const char * str);
+
+char * strchr(const char * str, int c);
+
+char * strcpy(char * dest, const char * src);
+
+int strcmp(const char * a, const char * b);
+
+int strncmp (const char * a, const char * b, size_t len);


### PR DESCRIPTION
 (fixes #138) (original tonyhax)

GCC seems to fortify the source code when enabling optimization, which is a problem because it sneakily replaces strncmp, bzero, etc... with other checked versions, which we have not defined.